### PR TITLE
tests: fix an error because calling `bytes.fromhex(b'')` is not allowed

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -152,7 +152,7 @@ def test_codec_physical_decode_ack(
         ),
         pytest.param(
             PhysicalDirection.FROM_METER,
-            b"",
+            "",
             DataLengthUnexpectedError,
             "Frame is of zero length.",
             id="empty",


### PR DESCRIPTION
Fixes: 8b6123b