### PR TITLE
Add more registers

### DIFF
--- a/src/pykmp/constants.py
+++ b/src/pykmp/constants.py
@@ -112,9 +112,25 @@ REGISTERS: Final[Mapping[int, str]] = {
     266: "E1HighRes",
     267: "Cooling energy E3 hires",
     279: "DIN meter ID",
+    292: "Water temperature",
+    # FIXME(jkt): Uncertain order (293-295), check them in May 2026 when a first "valid" log entry is made
+    293: "Min water temperature monthly",
+    294: "Max water temperature monthly",
+    295: "Avg water temperature monthly",
+    296: "Min water temperature daily",
+    297: "Max water temperature daily",
+    298: "Avg water temperature daily",
+    299: "Meter temperature",
+    300: "Min meter temperature monthly",
+    301: "Max meter temperature monthly",
+    302: "Avg meter temperature monthly",
+    303: "Min meter temperature daily",
+    304: "Max meter temperature daily",
+    305: "Avg meter temperature daily",
     # Documentation for 327-330 doesn't match what a KWM2231 water meter is sending
     327: "Target date 1",
     328: "Target date 2",
+    338: "Data quality",
     346: "Module SW rev",
     347: "Customer number",
     348: "Date and Time",  # TODO: unknown unit 79, 28591984415535
@@ -145,6 +161,17 @@ REGISTERS: Final[Mapping[int, str]] = {
     399: "T2 actual (one decimal)",
     400: "T1-T2 (one decimal)",
     404: "Meter Type",
+    # register 409: a combination of a bitfield and some duration tracking. Example values:
+    # 17184063489: dry 1-8 hrs, meter temperature too high: 9-24 hrs, no consumption: 9-24 hrs
+    # 17181966337: dry 1-8 hrs, meter temperature too high: 1-8 hrs, no consumption: 9-24 hrs
+    # 17179869185: dry 1-8 hrs, no consumption: 9-24 hrs
+    # 8589934593: dry 1-8 hrs, no consumption: 1-8 hrs
+    409: "Info hour counter",
+    440: "MaxFlow_H",
+    445: "MaxFlowDate_D",
+    446: "MinFlowDate_D",
+    # Seen in the logger. E.g. 128 is "meter temperature too high"
+    458: "Info code",
     473: "Energy E10",
     474: "Energy E11",
     477: "T3 time average day",
@@ -155,6 +182,7 @@ REGISTERS: Final[Mapping[int, str]] = {
     508: "P2 average hour",
     # Undocumented, but it "looks good" on a fresh meter from 2026
     582: "Maybe battery remaining",
+    583: "Accoustic noise last day",
     622: "V1 extra digit",
     # Undocumented, e.g., KWM2231
     640: "Meter type text",

--- a/src/pykmp/constants.py
+++ b/src/pykmp/constants.py
@@ -98,12 +98,23 @@ REGISTERS: Final[Mapping[int, str]] = {
     234: "l/imp for VA",
     235: "l/imp for VB",
     239: "Volume V1 hires",
+    241: "MaxFlow_D",
+    242: "MinFlow_D",
+    243: "Reverse flow V1",
+    254: "Type no",
+    257: "Pulse value V1",
+    258: "Pulse value V2",
+    268: "Q\N{LATIN SUBSCRIPT SMALL LETTER P} averaging time",
     # Undocumented (259 and 260), but it matches the info given by Multical 603 in the
     # diagnostics display
     259: "Nominal Q\N{LATIN SUBSCRIPT SMALL LETTER P} V1",
     260: "Nominal Q\N{LATIN SUBSCRIPT SMALL LETTER P} V2",
     266: "E1HighRes",
     267: "Cooling energy E3 hires",
+    279: "DIN meter ID",
+    # Documentation for 327-330 doesn't match what a KWM2231 water meter is sending
+    327: "Target date 1",
+    328: "Target date 2",
     346: "Module SW rev",
     347: "Customer number",
     348: "Date and Time",  # TODO: unknown unit 79, 28591984415535
@@ -129,6 +140,7 @@ REGISTERS: Final[Mapping[int, str]] = {
     # 388: something similar as 387?
     389: "Power max month date",
     # 390: something similar as 389?
+    394: "Config XYZ",
     398: "T1 actual (one decimal)",
     399: "T2 actual (one decimal)",
     400: "T1-T2 (one decimal)",  # Undocumented, but appears as such on Multical 603
@@ -141,8 +153,40 @@ REGISTERS: Final[Mapping[int, str]] = {
     506: "P2 average day",
     507: "P1 average hour",
     508: "P2 average hour",
+    # Undocumented, but it "looks good" on a fresh meter from 2026
+    582: "Maybe battery remaining",
+    622: "V1 extra digit",
+    # Undocumented, e.g., KWM2231
+    640: "Meter type text",
     # Undocumented, but it matches the actual interval on Multical 303
     675: "wM-Bus transmission interval",
+    # Undocumented (692-721), but it looks like a histogram readout
+    692: "Volume in flow bucket 1",
+    697: "Volume in flow bucket 2",
+    698: "Volume in flow bucket 3",
+    699: "Volume in flow bucket 4",
+    700: "Volume in flow bucket 5",
+    701: "Volume in flow bucket 6",
+    702: "Volume in flow bucket 7",
+    703: "Volume in flow bucket 8",
+    704: "Volume in flow bucket 9",
+    705: "Volume in flow bucket 10",
+    706: "Volume in flow bucket 11",
+    707: "Volume in flow bucket 12",
+    708: "Volume in flow bucket 13",
+    709: "Flow bucket 1",
+    710: "Flow bucket 2",
+    711: "Flow bucket 3",
+    712: "Flow bucket 4",
+    713: "Flow bucket 5",
+    714: "Flow bucket 6",
+    715: "Flow bucket 7",
+    716: "Flow bucket 8",
+    717: "Flow bucket 9",
+    718: "Flow bucket 10",
+    719: "Flow bucket 11",
+    720: "Flow bucket 12",
+    721: "Flow bucket 13",
     1001: "Fabrication No",
     1002: "Time",
     1003: "Date",

--- a/src/pykmp/constants.py
+++ b/src/pykmp/constants.py
@@ -133,17 +133,17 @@ REGISTERS: Final[Mapping[int, str]] = {
     381: "T1 time average hour",
     382: "T2 time average hour",
     383: "Flow V1 max year date",
-    # 384: something similar as 383?
+    384: "Flow V1 min year date",
     385: "Power max year date",
-    # 386: something similar as 385?
+    386: "Power min year date",
     387: "Flow V1 max month date",
-    # 388: something similar as 387?
+    388: "Flow V1 min month date",
     389: "Power max month date",
-    # 390: something similar as 389?
+    390: "Power min month time",
     394: "Config XYZ",
     398: "T1 actual (one decimal)",
     399: "T2 actual (one decimal)",
-    400: "T1-T2 (one decimal)",  # Undocumented, but appears as such on Multical 603
+    400: "T1-T2 (one decimal)",
     404: "Meter Type",
     473: "Energy E10",
     474: "Energy E11",


### PR DESCRIPTION
The histogram in particular is a nice feature :). Here's how it looks in the vendor's SW (a few minutes after I captured the packet trace, so some values have changed):

<img width="594" height="324" alt="image" src="https://github.com/user-attachments/assets/8bd3ad39-2953-43f4-be24-aa43b156b933" />

And here's the pykmp's output:

```
[...]
 689 → <unknown reg 689>            = 74260 no unit (number)
 690 → <unknown reg 690>            = 0 no unit (number)
 691 → <unknown reg 691>            = 0.900 l/h
 692 → Volume in flow bucket 1      = 0.250 l
 697 → Volume in flow bucket 2      = 0.000 m³
 698 → Volume in flow bucket 3      = 0.000 m³
 699 → Volume in flow bucket 4      = 0.019 m³
 700 → Volume in flow bucket 5      = 0.023 m³
 701 → Volume in flow bucket 6      = 0.488 m³
 702 → Volume in flow bucket 7      = 0.305 m³
 703 → Volume in flow bucket 8      = 0.000 m³
 704 → Volume in flow bucket 9      = 0.000 m³
 705 → Volume in flow bucket 10     = 0.000 m³
 706 → Volume in flow bucket 11     = 0.000 m³
 707 → Volume in flow bucket 12     = 0.000 m³
 708 → Volume in flow bucket 13     = 0.000 m³
 709 → Flow bucket 1                = 0 l/h
 710 → Flow bucket 2                = 1 l/h
 711 → Flow bucket 3                = 6 l/h
 712 → Flow bucket 4                = 32 l/h
 713 → Flow bucket 5                = 48 l/h
 714 → Flow bucket 6                = 480 l/h
 715 → Flow bucket 7                = 640 l/h
 716 → Flow bucket 8                = 800 l/h
 717 → Flow bucket 9                = 960 l/h
 718 → Flow bucket 10               = 1200 l/h
 719 → Flow bucket 11               = 1600 l/h
 720 → Flow bucket 12               = 2000 l/h
 721 → Flow bucket 13               = 15984 l/h
[...]
```